### PR TITLE
Upgrade my-day sample to SPFx 1.24.0-beta.2

### DIFF
--- a/samples/executive-sales-dashboard/assets/sample.json
+++ b/samples/executive-sales-dashboard/assets/sample.json
@@ -27,7 +27,7 @@
       },
       {
         "key": "SPFX-VERSION",
-        "value": "1.24.0-beta.1"
+        "value": "1.24.0-beta.2"
       }
     ],
     "thumbnails": [

--- a/samples/my-day/assets/sample.json
+++ b/samples/my-day/assets/sample.json
@@ -28,7 +28,7 @@
       },
       {
         "key": "SPFX-VERSION",
-        "value": "1.24.0-beta.1"
+        "value": "1.24.0-beta.2"
       }
     ],
     "thumbnails": [

--- a/samples/my-day/package-lock.json
+++ b/samples/my-day/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fluentui/react-components": "9.54.0",
         "@fluentui/react-icons": "2.0.270",
-        "@microsoft/sp-copilot-component": "1.24.0-beta.1",
+        "@microsoft/sp-copilot-component": "1.24.0-beta.2",
         "react": "17.0.1",
         "react-dom": "17.0.1",
         "tslib": "2.3.1",
@@ -18,10 +18,10 @@
         "zod-to-json-schema": "3.24.1"
       },
       "devDependencies": {
-        "@microsoft/eslint-config-spfx": "1.24.0-beta.1",
-        "@microsoft/eslint-plugin-spfx": "1.24.0-beta.1",
-        "@microsoft/spfx-heft-plugins": "1.24.0-beta.1",
-        "@microsoft/spfx-web-build-rig": "1.24.0-beta.1",
+        "@microsoft/eslint-config-spfx": "1.24.0-beta.2",
+        "@microsoft/eslint-plugin-spfx": "1.24.0-beta.2",
+        "@microsoft/spfx-heft-plugins": "1.24.0-beta.2",
+        "@microsoft/spfx-web-build-rig": "1.24.0-beta.2",
         "@rushstack/heft": "1.2.17",
         "@types/jest": "30.0.0",
         "@types/react": "17.0.45",
@@ -4577,13 +4577,13 @@
       }
     },
     "node_modules/@microsoft/eslint-config-spfx": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/eslint-config-spfx/-/eslint-config-spfx-1.24.0-beta.1.tgz",
-      "integrity": "sha1-hR85NBKBTwAgHEP190TpAYpqnTU=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/eslint-config-spfx/-/eslint-config-spfx-1.24.0-beta.2.tgz",
+      "integrity": "sha1-RtHqO+iQCtyrtQLg1A1manIkotQ=",
       "dev": true,
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/eslint-plugin-spfx": "1.24.0-beta.1",
+        "@microsoft/eslint-plugin-spfx": "1.24.0-beta.2",
         "@rushstack/eslint-config": "4.6.4",
         "@rushstack/eslint-plugin": "0.23.2",
         "@rushstack/eslint-plugin-security": "0.14.2",
@@ -4601,9 +4601,9 @@
       }
     },
     "node_modules/@microsoft/eslint-plugin-spfx": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/eslint-plugin-spfx/-/eslint-plugin-spfx-1.24.0-beta.1.tgz",
-      "integrity": "sha1-fDgimxDPRMS/5SRepkzj2on0rE8=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/eslint-plugin-spfx/-/eslint-plugin-spfx-1.24.0-beta.2.tgz",
+      "integrity": "sha1-4alRZkPDsHOfeVLlKTF3q7bA/hc=",
       "dev": true,
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
@@ -4665,20 +4665,20 @@
       "license": "0BSD"
     },
     "node_modules/@microsoft/sp-component-base": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-component-base/-/sp-component-base-1.24.0-beta.1.tgz",
-      "integrity": "sha1-R/SK9oWdVHF3sDo6Y0ZOy0PVUCU=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-component-base/-/sp-component-base-1.24.0-beta.2.tgz",
+      "integrity": "sha1-8mCYKM81MOVLTAU+wzh/nnZt6gc=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@fluentui/react": "^8.125.0",
         "@fluentui/react-components": "^9.70.0",
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-dynamic-data": "1.24.0-beta.1",
-        "@microsoft/sp-http": "1.24.0-beta.1",
-        "@microsoft/sp-lodash-subset": "1.24.0-beta.1",
-        "@microsoft/sp-module-interfaces": "1.24.0-beta.1",
-        "@microsoft/sp-page-context": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-dynamic-data": "1.24.0-beta.2",
+        "@microsoft/sp-http": "1.24.0-beta.2",
+        "@microsoft/sp-lodash-subset": "1.24.0-beta.2",
+        "@microsoft/sp-module-interfaces": "1.24.0-beta.2",
+        "@microsoft/sp-page-context": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "scheduler": "0.20.2",
         "tslib": "2.3.1"
@@ -4856,15 +4856,15 @@
       }
     },
     "node_modules/@microsoft/sp-copilot-component": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-copilot-component/-/sp-copilot-component-1.24.0-beta.1.tgz",
-      "integrity": "sha1-gjvdmLwk0X89+bbT05udL1CYxzo=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-copilot-component/-/sp-copilot-component-1.24.0-beta.2.tgz",
+      "integrity": "sha1-/QBG77zt4Y8xRGKdW05nIQExpNU=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-component-base": "1.24.0-beta.1",
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-module-interfaces": "1.24.0-beta.1",
+        "@microsoft/sp-component-base": "1.24.0-beta.2",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-module-interfaces": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       },
@@ -4873,12 +4873,12 @@
       }
     },
     "node_modules/@microsoft/sp-core-library": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-core-library/-/sp-core-library-1.24.0-beta.1.tgz",
-      "integrity": "sha1-Zums05Jcmsy1DK9+bfoZC6gpOKg=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-core-library/-/sp-core-library-1.24.0-beta.2.tgz",
+      "integrity": "sha1-MBPx8HWeKayZC26fPq54QgcZwh8=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-module-interfaces": "1.24.0-beta.1",
+        "@microsoft/sp-module-interfaces": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       },
@@ -4893,9 +4893,9 @@
       }
     },
     "node_modules/@microsoft/sp-css-loader": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-css-loader/-/sp-css-loader-1.24.0-beta.1.tgz",
-      "integrity": "sha1-mkrNMI4Po90CK7RsYkpHIWMCYR4=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-css-loader/-/sp-css-loader-1.24.0-beta.2.tgz",
+      "integrity": "sha1-sP4pOUFn8PQKPRJbLbFmayzcipg=",
       "dev": true,
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
@@ -4923,28 +4923,28 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/sp-diagnostics": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-diagnostics/-/sp-diagnostics-1.24.0-beta.1.tgz",
-      "integrity": "sha1-b9jdRFD0FoZU7dA7myKPiEDz7Yk=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-diagnostics/-/sp-diagnostics-1.24.0-beta.2.tgz",
+      "integrity": "sha1-+UGes9/MzBX5b3KGaRmF31PBWn8=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-lodash-subset": "1.24.0-beta.1"
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-lodash-subset": "1.24.0-beta.2"
       },
       "engines": {
         "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
       }
     },
     "node_modules/@microsoft/sp-dynamic-data": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.24.0-beta.1.tgz",
-      "integrity": "sha1-Ekmf6y1vWuCPyfd5/zMZvTuyEO8=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.24.0-beta.2.tgz",
+      "integrity": "sha1-/G0cS5qllP0KzgWxhpbu0Sn2w48=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-lodash-subset": "1.24.0-beta.1",
-        "@microsoft/sp-module-interfaces": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-lodash-subset": "1.24.0-beta.2",
+        "@microsoft/sp-module-interfaces": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       },
@@ -4953,15 +4953,15 @@
       }
     },
     "node_modules/@microsoft/sp-http": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-http/-/sp-http-1.24.0-beta.1.tgz",
-      "integrity": "sha1-H9sHBtKCS0YStx9YHLrsqj9h/u4=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-http/-/sp-http-1.24.0-beta.2.tgz",
+      "integrity": "sha1-X8/aGK9xBkfxyjCTHbLPbCm1JrE=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-http-base": "1.24.0-beta.1",
-        "@microsoft/sp-http-msgraph": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-http-base": "1.24.0-beta.2",
+        "@microsoft/sp-http-msgraph": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       },
@@ -4970,50 +4970,50 @@
       }
     },
     "node_modules/@microsoft/sp-http-base": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-http-base/-/sp-http-base-1.24.0-beta.1.tgz",
-      "integrity": "sha1-Em9SGlaro069U4G7N8f08TljGig=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-http-base/-/sp-http-base-1.24.0-beta.2.tgz",
+      "integrity": "sha1-3oJbmqUrLOCMJCdUdL89CS7Y03E=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-page-context": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-page-context": "1.24.0-beta.2",
         "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.53.0",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       }
     },
     "node_modules/@microsoft/sp-http-msgraph": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.24.0-beta.1.tgz",
-      "integrity": "sha1-VB1hqIqSwdUiJ5PGR0F7QIhIlEE=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.24.0-beta.2.tgz",
+      "integrity": "sha1-qyaZwscXOkCjfXAMsLo1Utq2OzU=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@microsoft/microsoft-graph-client": "3.0.2",
         "@microsoft/microsoft-graph-clientv1": "npm:@microsoft/microsoft-graph-client@1.7.2-spfx",
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-http-base": "1.24.0-beta.1",
-        "@microsoft/sp-loader": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-http-base": "1.24.0-beta.2",
+        "@microsoft/sp-loader": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       }
     },
     "node_modules/@microsoft/sp-loader": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-loader/-/sp-loader-1.24.0-beta.1.tgz",
-      "integrity": "sha1-VeIk2QCCSkJp4ThS6I3cFq4c2os=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-loader/-/sp-loader-1.24.0-beta.2.tgz",
+      "integrity": "sha1-LUA9taywyFgsRvvGoRoVwuPlfIM=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@fluentui/react": "^8.125.0",
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-dynamic-data": "1.24.0-beta.1",
-        "@microsoft/sp-http-base": "1.24.0-beta.1",
-        "@microsoft/sp-lodash-subset": "1.24.0-beta.1",
-        "@microsoft/sp-module-interfaces": "1.24.0-beta.1",
-        "@microsoft/sp-odata-types": "1.24.0-beta.1",
-        "@microsoft/sp-page-context": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-dynamic-data": "1.24.0-beta.2",
+        "@microsoft/sp-http-base": "1.24.0-beta.2",
+        "@microsoft/sp-lodash-subset": "1.24.0-beta.2",
+        "@microsoft/sp-module-interfaces": "1.24.0-beta.2",
+        "@microsoft/sp-odata-types": "1.24.0-beta.2",
+        "@microsoft/sp-page-context": "1.24.0-beta.2",
         "@rushstack/loader-raw-script": "1.6.17",
         "@swc/helpers": "^0.5.12",
         "@types/requirejs": "2.1.29",
@@ -5032,9 +5032,9 @@
       }
     },
     "node_modules/@microsoft/sp-lodash-subset": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.24.0-beta.1.tgz",
-      "integrity": "sha1-KhP9ghsIwRquMJtDiN/AHl3iJqw=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.24.0-beta.2.tgz",
+      "integrity": "sha1-w/H8xewI2UOUg1YizbMkraizIJU=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@swc/helpers": "^0.5.12",
@@ -5046,9 +5046,9 @@
       }
     },
     "node_modules/@microsoft/sp-module-interfaces": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.24.0-beta.1.tgz",
-      "integrity": "sha1-eV1AO/z+Xl380V/fHb4h2dj68JQ=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.24.0-beta.2.tgz",
+      "integrity": "sha1-4m93sDMORdKxReaw8RYDd8IEiLA=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@rushstack/node-core-library": "5.23.1",
@@ -5060,9 +5060,9 @@
       }
     },
     "node_modules/@microsoft/sp-odata-types": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-odata-types/-/sp-odata-types-1.24.0-beta.1.tgz",
-      "integrity": "sha1-o16sh0Zkg6jbgVE3yGLYEW7xXDo=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-odata-types/-/sp-odata-types-1.24.0-beta.2.tgz",
+      "integrity": "sha1-tXTGJJO70nFQ1GYxXTPv1YbKL4Q=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@swc/helpers": "^0.5.12",
@@ -5073,16 +5073,16 @@
       }
     },
     "node_modules/@microsoft/sp-page-context": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-page-context/-/sp-page-context-1.24.0-beta.1.tgz",
-      "integrity": "sha1-o692+o7KqrOSov05nRpXRvQC3BQ=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/sp-page-context/-/sp-page-context-1.24.0-beta.2.tgz",
+      "integrity": "sha1-sTAww2j7z7QEzG1Qa54knvy0448=",
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.24.0-beta.1",
-        "@microsoft/sp-diagnostics": "1.24.0-beta.1",
-        "@microsoft/sp-dynamic-data": "1.24.0-beta.1",
-        "@microsoft/sp-lodash-subset": "1.24.0-beta.1",
-        "@microsoft/sp-odata-types": "1.24.0-beta.1",
+        "@microsoft/sp-core-library": "1.24.0-beta.2",
+        "@microsoft/sp-diagnostics": "1.24.0-beta.2",
+        "@microsoft/sp-dynamic-data": "1.24.0-beta.2",
+        "@microsoft/sp-lodash-subset": "1.24.0-beta.2",
+        "@microsoft/sp-odata-types": "1.24.0-beta.2",
         "@swc/helpers": "^0.5.12",
         "tslib": "2.3.1"
       },
@@ -5091,16 +5091,16 @@
       }
     },
     "node_modules/@microsoft/spfx-heft-plugins": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.24.0-beta.1.tgz",
-      "integrity": "sha1-xVWucNFWPFH9OGCVA+bA6nxAoow=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.24.0-beta.2.tgz",
+      "integrity": "sha1-GPp0y6/UUW7yi1qJUqIXQ4Whkno=",
       "dev": true,
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@azure/storage-blob": "~12.26.0",
         "@microsoft/app-manifest": "1.1.0",
-        "@microsoft/sp-css-loader": "1.24.0-beta.1",
-        "@microsoft/sp-module-interfaces": "1.24.0-beta.1",
+        "@microsoft/sp-css-loader": "1.24.0-beta.2",
+        "@microsoft/sp-module-interfaces": "1.24.0-beta.2",
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@rushstack/heft-config-file": "0.20.10",
         "@rushstack/localization-utilities": "0.15.17",
@@ -5133,14 +5133,14 @@
       }
     },
     "node_modules/@microsoft/spfx-web-build-rig": {
-      "version": "1.24.0-beta.1",
-      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/spfx-web-build-rig/-/spfx-web-build-rig-1.24.0-beta.1.tgz",
-      "integrity": "sha1-sbuCSM6+SYLRpxL1YH9Lb0o0dF0=",
+      "version": "1.24.0-beta.2",
+      "resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/spfx-web-build-rig/-/spfx-web-build-rig-1.24.0-beta.2.tgz",
+      "integrity": "sha1-pvzgnjw4aj7gu5pDQOTHrNAuW8s=",
       "dev": true,
       "license": "https://aka.ms/spfx/license",
       "dependencies": {
         "@microsoft/api-extractor": "7.58.7",
-        "@microsoft/spfx-heft-plugins": "1.24.0-beta.1",
+        "@microsoft/spfx-heft-plugins": "1.24.0-beta.2",
         "@rushstack/heft": "1.2.17",
         "@rushstack/heft-dev-cert-plugin": "1.1.18",
         "@rushstack/heft-jest-plugin": "2.0.6",

--- a/samples/my-day/package.json
+++ b/samples/my-day/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@fluentui/react-components": "9.54.0",
     "@fluentui/react-icons": "2.0.270",
-    "@microsoft/sp-copilot-component": "1.24.0-beta.1",
+    "@microsoft/sp-copilot-component": "1.24.0-beta.2",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "tslib": "2.3.1",
@@ -22,10 +22,10 @@
     "zod-to-json-schema": "3.24.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-spfx": "1.24.0-beta.1",
-    "@microsoft/eslint-plugin-spfx": "1.24.0-beta.1",
-    "@microsoft/spfx-heft-plugins": "1.24.0-beta.1",
-    "@microsoft/spfx-web-build-rig": "1.24.0-beta.1",
+    "@microsoft/eslint-config-spfx": "1.24.0-beta.2",
+    "@microsoft/eslint-plugin-spfx": "1.24.0-beta.2",
+    "@microsoft/spfx-heft-plugins": "1.24.0-beta.2",
+    "@microsoft/spfx-web-build-rig": "1.24.0-beta.2",
     "@rushstack/heft": "1.2.17",
     "@types/jest": "30.0.0",
     "@types/react": "17.0.45",

--- a/samples/time-off-absence/assets/sample.json
+++ b/samples/time-off-absence/assets/sample.json
@@ -28,7 +28,7 @@
       },
       {
         "key": "SPFX-VERSION",
-        "value": "1.24.0-beta.1"
+        "value": "1.24.0-beta.2"
       }
     ],
     "thumbnails": [

--- a/samples/zava-retail-store/assets/sample.json
+++ b/samples/zava-retail-store/assets/sample.json
@@ -28,7 +28,7 @@
       },
       {
         "key": "SPFX-VERSION",
-        "value": "1.24.0-beta.1"
+        "value": "1.24.0-beta.2"
       }
     ],
     "thumbnails": [


### PR DESCRIPTION
## Summary

Aligns the **my-day** sample with the other samples, which already target SPFx `1.24.0-beta.2`. The `my-day` sample was still on `1.24.0-beta.1`.

## Changes

- **`my-day/package.json`** — bumped the 5 `@microsoft/*` SPFx dev-preview packages from `beta.1` → `beta.2`:
  - `@microsoft/sp-copilot-component` (dependencies)
  - `@microsoft/eslint-config-spfx`, `@microsoft/eslint-plugin-spfx`, `@microsoft/spfx-heft-plugins`, `@microsoft/spfx-web-build-rig` (devDependencies)
- **`my-day/package-lock.json`** — updated the corresponding root specifiers and the 18 `@microsoft/*` entries to `beta.2` (versions, resolved URLs, integrity hashes, and the newly-added `@swc/helpers`/`tslib` deps on `sp-copilot-component`).
- **`assets/sample.json`** (all four samples: my-day, time-off-absence, zava-retail-store, executive-sales-dashboard) — fixed the stale `SPFX-VERSION` metadata field, which read `1.24.0-beta.1` everywhere, to `1.24.0-beta.2`.

After these changes, a repo-wide search finds **zero** `1.24.0-beta.1` references remaining in `samples/`.

## Note on the lock file

The SPFx dev-preview packages resolve only from a private feed that was not reachable from the environment where this change was prepared, so `package-lock.json` was updated by transplanting the identical `beta.2` entries from a sibling sample's lock file (equivalent to a real install). All entries are byte-identical across the sibling `beta.2` locks, dev flags match, and every transitive dependency resolves. **Please run `npm install` in an authenticated environment to confirm the lock file.**