### PR TITLE
Fix gallery deployment metrics step

### DIFF
--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           {
             echo "## Gallery artifact"
-            echo "- Catalog entries: $(node -p \"require('./site/dist/catalog.json').components.length\")"
+            echo "- Catalog entries: $(node -p "require('./site/dist/catalog.json').components.length")"
             echo "- Pages: $(find site/dist -name index.html -o -name 404.html | wc -l)"
             echo "- Optimized previews: $(find site/dist/generated/previews -name '*.webp' | wc -l)"
             echo "- Site size: $(du -sh site/dist | cut -f1)"


### PR DESCRIPTION
# Pull Request

## Description

Fix the GitHub Pages deployment workflow's metrics step. Escaped quotes caused Bash to parse the `node -p` expression incorrectly after the gallery build and browser tests had succeeded, preventing artifact upload and deployment.

## Validation

- [x] The exact metrics block passes Git Bash syntax validation.
- [x] The metrics block executes against the built site and reports 16 catalog entries, 22 pages, 32 optimized previews, and a 3.4 MB artifact.
- [x] The workflow file has no editor diagnostics.
- [x] Sample-content checklist items are not applicable to this workflow-only change.