### PR TITLE
Validate Events gallery counts

### DIFF
--- a/site/tests/e2e/gallery.spec.ts
+++ b/site/tests/e2e/gallery.spec.ts
@@ -5,11 +5,28 @@ test('catalog loads and filters without layout navigation', async ({ page }) => 
   await page.goto('./');
 
   await expect(page.getByRole('heading', { level: 1, name: 'Copilot Components' })).toBeVisible();
-  await expect(page.locator('[data-component-card]')).toHaveCount(16);
+  await expect(page.locator('[data-component-card]')).toHaveCount(17);
   await page.getByRole('searchbox', { name: 'Search components' }).fill('Work IQ');
   await expect(page.locator('[data-component-card]:visible')).toHaveCount(1);
   await expect(page.getByRole('heading', { level: 3, name: 'Work IQ Answers' })).toBeVisible();
   await expect(page).toHaveURL(/\?q=Work(?:%20|\+)IQ$/);
+});
+
+test('events sample increments catalog and contributor counts', async ({ page }) => {
+  await page.goto('./');
+
+  await expect(page.locator('.catalog-stat')).toContainText('17community components');
+  await expect(page.locator('#result-count')).toHaveText('Showing 17 components');
+  await expect(page.getByRole('heading', { level: 3, name: 'SharePoint Events Copilot Agent' })).toBeVisible();
+
+  await page.getByRole('combobox', { name: 'Contributor' }).selectOption('joaojmendes');
+  await expect(page.locator('[data-component-card]:visible')).toHaveCount(2);
+  await expect(page.locator('#result-count')).toHaveText('Showing 2 matching components');
+  await expect(page).toHaveURL(/\?author=joaojmendes$/);
+
+  await page.goto('./contributors/');
+  const contributor = page.locator('.contributor-card').filter({ hasText: 'João Mendes' });
+  await expect(contributor).toContainText('2 component samples');
 });
 
 test('component detail exposes source, download, and documentation', async ({ page }) => {
@@ -41,7 +58,15 @@ test('public catalog matches the rendered component count', async ({ request }) 
   expect(response.ok()).toBeTruthy();
   const catalog = await response.json();
   expect(catalog.version).toBe(1);
-  expect(catalog.components).toHaveLength(16);
+  expect(catalog.components).toHaveLength(17);
+  expect(catalog.components).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      slug: 'events',
+      title: 'SharePoint Events Copilot Agent',
+      sourceUrl: 'https://github.com/pnp/spfx-copilot-components/tree/main/samples/events',
+      authors: [expect.objectContaining({ gitHubAccount: 'joaojmendes' })],
+    }),
+  ]));
   expect(catalog.excludedSamples).toEqual([
     { slug: 'm365-service-health', reason: 'Missing assets/sample.json' },
   ]);

--- a/todo.md
+++ b/todo.md
@@ -1,19 +1,19 @@
 # Gallery release checklist
 
-The Copilot Components gallery is implemented and validated locally. The site currently generates 16 catalog entries from 17 sample folders; `m365-service-health` is explicitly excluded because it has no `assets/sample.json`.
+The Copilot Components gallery is live and validated. The site currently generates 17 catalog entries from 18 sample folders; `m365-service-health` is explicitly excluded because it has no `assets/sample.json`.
 
 ## Publish
 
-- [ ] Create a feature branch from the current local changes, commit them, and open a pull request.
-- [ ] Confirm the `Validate catalog and site` pull request check passes.
-- [ ] In **Settings > Pages**, set the source to **GitHub Actions**.
-- [ ] Merge the pull request to `main` and confirm the `Deploy gallery` workflow succeeds.
-- [ ] Smoke test <https://pnp.github.io/spfx-copilot-components/>, `catalog.json`, a sample detail page, and an optimized preview.
+- [x] Create a feature branch from the current local changes, commit them, and open a pull request.
+- [x] Confirm the `Validate catalog and site` pull request check passes.
+- [x] In **Settings > Pages**, set the source to **GitHub Actions**.
+- [x] Merge the pull request to `main` and confirm the `Deploy gallery` workflow succeeds.
+- [x] Smoke test <https://pnp.github.io/spfx-copilot-components/>, `catalog.json`, a sample detail page, and an optimized preview.
 - [ ] Add `Validate catalog and site` as a required branch-protection check after its first successful pull request run.
 
 ## Sample metadata follow-up
 
-These items are not blockers for publishing the current 16-component gallery and require a separate sample-level content pass.
+These items are not blockers for the live 17-component gallery and require a separate sample-level content pass.
 
 - [ ] Add verified `samples/m365-service-health/assets/sample.json`, referencing one of its existing screenshots as the first ordered image.
 - [ ] Audit all sample READMEs, metadata, and gallery media; record accepted exceptions separately if a formal content-quality review is required.


### PR DESCRIPTION
# Pull Request

## Description

Update the gallery validation contract after PR #34 added the SharePoint Events sample. The deployment correctly generated 17 catalog entries, but Playwright still expected 16 and blocked Pages deployment.

This change also verifies the Events card and normalized catalog record, the 17-component overall counts, João Mendes' two matching samples, and his contributor-page total. The gallery release checklist now reflects the completed setup and current 17-of-18 sample coverage.

## Validation

- [x] Production build generates 17 components from 18 sample folders and 23 pages.
- [x] Playwright desktop/mobile and accessibility suite: 11 passed, 1 expected skip.
- [x] Events source URL is normalized to `pnp/spfx-copilot-components`.
- [x] No editor diagnostics in the changed files.
- [x] Sample-content checklist items are not applicable to this validation-only follow-up.